### PR TITLE
Updated bg-mask pattern to follow README

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,7 @@ import type { Preset } from 'unocss'
 const availablePatterns = Object.keys(patterns)
 const availablePatternsGroup = `(${availablePatterns.join('|')})`
 const bgHeroRegex = new RegExp(`^bg-hero-${availablePatternsGroup}-(.*)$`)
-const bgMaskHeroRegex = new RegExp(`^mask-bg-hero-${availablePatternsGroup}$`)
+const bgMaskHeroRegex = new RegExp(`^bg-mask-hero-${availablePatternsGroup}$`)
 
 export function presetHeroPatterns(): Preset {
   return {


### PR DESCRIPTION
Readme suggests to use `bg-mask-hero-{pattern}` but the code recognized `mask-bg-hero-{pattern}`, so I did a quick fix to make the code use same classname as Readme