### PR TITLE
fix: added repeating background property

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -40,6 +40,7 @@ export function presetHeroPatterns(): Preset {
           if (pattern) {
             return {
               '-webkit-mask-image': getBgImage(pattern),
+              'background-repeat': 'repeat',
             }
           }
         },


### PR DESCRIPTION
It works fine under normal conditions, but stops working while used with `@unocss/reset`,
turns out background repeat gets overwritten by css reset, so it no longer works properly until `bg-repeat` class is added.
So, I added background repeat rule to the class itself, because I think background repeat was an intended property.